### PR TITLE
improve no/wrong password exeption

### DIFF
--- a/src/pihole6api/conn.py
+++ b/src/pihole6api/conn.py
@@ -89,13 +89,13 @@ class PiHole6Connection:
                         logger.debug("Authentication successful")
                         return  # Successful authentication
                     else:
-                        if "session" in data and data["session"]["message"]:
-                            logger.error(data["session"]["message"])
+                        if data.get("session"):
+                            logger.error(data["session"].get("message", "API failed without message"))
                         last_exception = Exception("Authentication failed: Invalid session response")
                 else:
                     # Try to extract an error message from the response
                     try:
-                        error_msg = response.json().get("error", {}).get("message", "Unknown error")
+                        error_msg = response.json().get("session", {}).get("message", "Unknown error")
                     except (json.decoder.JSONDecodeError, ValueError):
                         error_msg = f"HTTP {response.status_code}: {response.reason}"
                     last_exception = Exception(f"Authentication failed: {error_msg}")

--- a/src/pihole6api/conn.py
+++ b/src/pihole6api/conn.py
@@ -82,13 +82,15 @@ class PiHole6Connection:
                 
                 if response.status_code == 200:
                     data = response.json()
-                    if "session" in data and data["session"]["valid"]:
+                    if "session" in data and data["session"]["valid"] and data["session"]["validity"] > 0:
                         self.session_id = data["session"]["sid"]
                         self.csrf_token = data["session"]["csrf"]
                         self.validity = data["session"]["validity"]
                         logger.debug("Authentication successful")
                         return  # Successful authentication
                     else:
+                        if "session" in data and data["session"]["message"]:
+                            logger.error(data["session"]["message"])
                         last_exception = Exception("Authentication failed: Invalid session response")
                 else:
                     # Try to extract an error message from the response


### PR DESCRIPTION
stupid me didn't set a password and the output was bit misleading. 

```
Authentication attempt 1 failed: 'csrf'
Authentication attempt 2 failed: 'csrf'
Authentication attempt 3 failed: 'csrf'
All authentication attempts failed: 'csrf'
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<snip>site-packages/pihole6api/client.py", line 22, in __init__
    self.connection = PiHole6Connection(base_url, password)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<snip>site-packages/pihole6api/conn.py", line 67, in __init__
    self._authenticate()
  File "<snip>site-packages/pihole6api/conn.py", line 112, in _authenticate
    raise last_exception
  File "<snip>site-packages/pihole6api/conn.py", line 87, in _authenticate
    self.csrf_token = data["session"]["csrf"]
                      ~~~~~~~~~~~~~~~^^^^^^^^
KeyError: 'csrf'
```
With the fix:
```
no password set
no password set
no password set
All authentication attempts failed: Authentication failed: Invalid session response
```
also it looks like the json for a wrong password has changed which is now

```
Exception: Authentication failed: password incorrect
```