### PR TITLE
Remove the default TTL for cname records

### DIFF
--- a/src/pihole6api/config.py
+++ b/src/pihole6api/config.py
@@ -101,26 +101,32 @@ class PiHole6Configuration:
         encoded_value = urllib.parse.quote(f"{ip} {host}")
         return self.connection.delete(f"config/dns/hosts/{encoded_value}")
 
-    def add_local_cname(self, host, target, ttl=300):
+    def add_local_cname(self, host, target, ttl=None):
         """
         Add a local CNAME record to Pi-hole.
 
         :param host: The CNAME alias (e.g., "bar.xyz")
         :param target: The target hostname (e.g., "foo.dev")
-        :param ttl: Time-to-live for the record (default: 300)
+        :param ttl: Time-to-live for the record (None for no TTL)
         :return: API response
         """
-        encoded_value = urllib.parse.quote(f"{host},{target},{ttl}")
+        if ttl is None:
+            encoded_value = urllib.parse.quote(f"{host},{target}")
+        else:
+            encoded_value = urllib.parse.quote(f"{host},{target},{ttl}")
         return self.connection.put(f"config/dns/cnameRecords/{encoded_value}")
 
-    def remove_local_cname(self, host, target, ttl=300):
+    def remove_local_cname(self, host, target, ttl=None):
         """
         Remove a local CNAME record from Pi-hole.
 
         :param host: The CNAME alias (e.g., "bar.xyz")
         :param target: The target hostname (e.g., "foo.dev")
-        :param ttl: Time-to-live for the record (default: 300)
+        :param ttl: Time-to-live for the record (None for no TTL)
         :return: API response
         """
-        encoded_value = urllib.parse.quote(f"{host},{target},{ttl}")
+        if ttl is None:
+            encoded_value = urllib.parse.quote(f"{host},{target}")
+        else:
+            encoded_value = urllib.parse.quote(f"{host},{target},{ttl}")
         return self.connection.delete(f"config/dns/cnameRecords/{encoded_value}")


### PR DESCRIPTION
Hello,

I have been trying to use your sbarbett/pihole-ansible repository to define my local DNS records in Ansible.  My Pi-Hole has been configured manually previously, but I was attempting to match its configuration in Ansible.  I was having issues with my CNAME records always reporting as changing.  I debugged and traced my issue to the way the API handles the TTL value.

In my Pi-Hole I have no TTLs configured.  The API always provides a TTL value for the CNAME add and remove functions, if not it adds a default 300.  It is not able to remove my records due to the `{encoded_value}` of the delete request always containing a `,{ttl}` parameter.

I have adapted the `add_local_cname` and `remove_local_cname` functions to allow TTL to be not set or None.  In this case the APIs will exclude that parameter from the request.

I believe this change matches the specification defined by the Pi-Hole server.  This information is copied from the `<pihole-address>/admin/settings/all` page under the section `dns.cnameRecords`: Allowed value: Array of CNAMEs each on in one of the following forms: "<cname\>,<target\>[,<TTL\>]"

Please let me know if you have any questions about this change, or if you'd like me to make any other adaptions.