### PR TITLE
fix: send list type in query param

### DIFF
--- a/src/pihole6api/list_management.py
+++ b/src/pihole6api/list_management.py
@@ -24,13 +24,12 @@ class PiHole6ListManagement:
 
         payload = {
             "address": address if isinstance(address, list) else [address],
-            "type": list_type,
             "comment": comment,
             "groups": groups if groups else [],
             "enabled": enabled
         }
 
-        return self.connection.post("lists", data=payload)
+        return self.connection.post(f"lists?type={list_type}", data=payload)
 
     def batch_delete_lists(self, lists):
         """
@@ -76,13 +75,12 @@ class PiHole6ListManagement:
         """
         encoded_address = urllib.parse.quote(address, safe="")
         payload = {
-            "type": list_type,
             "comment": comment,
             "groups": groups if groups else [],
             "enabled": enabled
         }
 
-        return self.connection.put(f"lists/{encoded_address}", data=payload)
+        return self.connection.put(f"lists/{encoded_address}?type={list_type}", data=payload)
 
     def delete_list(self, address, list_type):
         """


### PR DESCRIPTION
## Summary
- move list_type from JSON payload into the query string for add/update list calls

## Rationale
Pi-hole v6 API requires `type` as a query param (`?type=block|allow`); sending it in the JSON body returns:
"Invalid request: Specify type parameter (should be either "allow" or "block")".

## Testing
- ran add_list/update_list via sbarbett.pihole role against Pi-hole v6; lists now appear in UI