### PR TITLE
Skip Authentication When Password is not Provided

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "requests >=2.26.0",
+    "requests[socks] >=2.26.0",
 ]
 
 [project.urls]

--- a/src/pihole6api/conn.py
+++ b/src/pihole6api/conn.py
@@ -63,8 +63,9 @@ class PiHole6Connection:
         # Set timeout
         self.session.timeout = connection_timeout
         
-        # Authenticate upon initialization
-        self._authenticate()
+        if password is not None and password != '':
+            # Authenticate upon initialization
+            self._authenticate()
 
     def _authenticate(self):
         """Authenticate with the Pi-hole API and store session ID and CSRF token.
@@ -115,6 +116,9 @@ class PiHole6Connection:
 
     def _get_headers(self):
         """Return headers including the authentication SID and CSRF token."""
+        if self.password is None or self.password == '':
+            return {}
+
         if not self.session_id or not self.csrf_token:
             self._authenticate()
 


### PR DESCRIPTION
- Allows the user to work with the Pi-hole API when password authentication is disabled
- Use case stems from the need to call the API via a script, but prefer to disable the password for the Web UI since authentication is handled by Authelia

> Note: Additional change to support SOCKS